### PR TITLE
add RVV optimization for ZSTD_row_getMatchMask

### DIFF
--- a/lib/compress/zstd_lazy.c
+++ b/lib/compress/zstd_lazy.c
@@ -1051,6 +1051,69 @@ ZSTD_row_getNEONMask(const U32 rowEntries, const BYTE* const src, const BYTE tag
 }
 #endif
 
+#if defined(ZSTD_ARCH_RISCV_RVV) && (__riscv_xlen == 64)
+FORCE_INLINE_TEMPLATE ZSTD_VecMask
+ZSTD_row_getRVVMask(const U32 rowEntries, const BYTE* const src, const BYTE tag, const U32 headGrouped)
+{
+    ZSTD_VecMask matches = 0;
+
+    if (rowEntries == 16) {
+        size_t vl = 16;
+        vuint8m1_t chunk_v8 = __riscv_vle8_v_u8m1(src, vl);
+        vuint16m2_t chunk_v16 = __riscv_vwaddu_vx_u16m2(chunk_v8, 0, vl);
+        vbool8_t cmp_mask = __riscv_vmseq_vx_u16m2_b8(chunk_v16, tag, vl);
+	
+        vuint16m2_t one_v = __riscv_vmv_v_x_u16m2(1, vl);
+        vuint16m2_t index_v = __riscv_vid_v_u16m2(vl);
+        vuint16m2_t powers_of_2_v = __riscv_vsll_vv_u16m2(one_v, index_v, vl);
+        
+        vuint16m2_t v_zero = __riscv_vmv_v_x_u16m2(0, vl);
+        vuint16m2_t selected_bits_v = __riscv_vmerge_vvm_u16m2(powers_of_2_v, v_zero, cmp_mask, vl);
+
+	vuint16m1_t reduction_v = __riscv_vredor_vs_u16m2_u16m1(selected_bits_v, __riscv_vmv_s_x_u16m1(0, vl), vl);
+matches = __riscv_vmv_x_s_u16m1_u16(reduction_v);
+
+    } else if (rowEntries == 32) {
+        size_t vl = 32;
+        vuint8m1_t chunk_v8 = __riscv_vle8_v_u8m1(src, vl);
+        /* Widen in two steps: 8-bit -> 16-bit, then 16-bit -> 32-bit */
+        vuint16m2_t chunk_v16 = __riscv_vwaddu_vx_u16m2(chunk_v8, 0, vl);
+        vuint32m4_t chunk_v32 = __riscv_vwaddu_vx_u32m4(chunk_v16, 0, vl);
+        vbool8_t cmp_mask = __riscv_vmseq_vx_u32m4_b8(chunk_v32, tag, vl);
+
+        vuint32m4_t one_v = __riscv_vmv_v_x_u32m4(1, vl);
+        vuint32m4_t index_v = __riscv_vid_v_u32m4(vl);
+        vuint32m4_t powers_of_2_v = __riscv_vsll_vv_u32m4(one_v, index_v, vl);
+
+        vuint32m4_t v_zero = __riscv_vmv_v_x_u32m4(0, vl);
+        vuint32m4_t selected_bits_v = __riscv_vmerge_vvm_u32m4(powers_of_2_v, v_zero, cmp_mask, vl);
+        
+vuint32m1_t reduction_v = __riscv_vredor_vs_u32m4_u32m1(selected_bits_v, __riscv_vmv_s_x_u32m1(0, vl), vl);
+matches = __riscv_vmv_x_s_u32m1_u32(reduction_v);
+    } else { /* rowEntries == 64 */
+        size_t vl = 64;
+        vuint8m1_t chunk_v8 = __riscv_vle8_v_u8m1(src, vl);
+        /* Widen in three steps: 8 -> 16 -> 32 -> 64 */
+        vuint16m2_t chunk_v16 = __riscv_vwaddu_vx_u16m2(chunk_v8, 0, vl);
+        vuint32m4_t chunk_v32 = __riscv_vwaddu_vx_u32m4(chunk_v16, 0, vl);
+        vuint64m8_t chunk_v64 = __riscv_vwaddu_vx_u64m8(chunk_v32, 0, vl);
+        vbool8_t cmp_mask = __riscv_vmseq_vx_u64m8_b8(chunk_v64, tag, vl);
+
+        vuint64m8_t one_v = __riscv_vmv_v_x_u64m8(1, vl);
+        vuint64m8_t index_v = __riscv_vid_v_u64m8(vl);
+        vuint64m8_t powers_of_2_v = __riscv_vsll_vv_u64m8(one_v, index_v, vl);
+
+        vuint64m8_t v_zero = __riscv_vmv_v_x_u64m8(0, vl);
+        vuint64m8_t selected_bits_v = __riscv_vmerge_vvm_u64m8(powers_of_2_v, v_zero, cmp_mask, vl);
+
+vuint64m1_t reduction_v = __riscv_vredor_vs_u64m8_u64m1(selected_bits_v, __riscv_vmv_s_x_u64m1(0, vl), vl);
+matches = __riscv_vmv_x_s_u64m1_u64(reduction_v);
+    }
+
+    return ZSTD_rotateRight_U64(matches, headGrouped);
+}
+#endif
+
 /* Returns a ZSTD_VecMask (U64) that has the nth group (determined by
  * ZSTD_row_matchMaskGroupWidth) of bits set to 1 if the newly-computed "tag"
  * matches the hash at the nth position in a row of the tagTable.
@@ -1069,14 +1132,17 @@ ZSTD_row_getMatchMask(const BYTE* const tagRow, const BYTE tag, const U32 headGr
 
     return ZSTD_row_getSSEMask(rowEntries / 16, src, tag, headGrouped);
 
-#else /* SW or NEON-LE */
-
-# if defined(ZSTD_ARCH_ARM_NEON)
+# elif defined(ZSTD_ARCH_ARM_NEON)
   /* This NEON path only works for little endian - otherwise use SWAR below */
     if (MEM_isLittleEndian()) {
         return ZSTD_row_getNEONMask(rowEntries, src, tag, headGrouped);
     }
-# endif /* ZSTD_ARCH_ARM_NEON */
+
+# elif defined(ZSTD_ARCH_RISCV_RVV) && (__riscv_xlen == 64)
+
+    return ZSTD_row_getRVVMask(rowEntries, src, tag, headGrouped);
+
+#else
     /* SWAR */
     {   const int chunkSize = sizeof(size_t);
         const size_t shiftAmount = ((chunkSize * 8) - chunkSize);

--- a/lib/compress/zstd_lazy.c
+++ b/lib/compress/zstd_lazy.c
@@ -1132,17 +1132,20 @@ ZSTD_row_getMatchMask(const BYTE* const tagRow, const BYTE tag, const U32 headGr
 
     return ZSTD_row_getSSEMask(rowEntries / 16, src, tag, headGrouped);
 
-# elif defined(ZSTD_ARCH_ARM_NEON)
+#elif defined(ZSTD_ARCH_RISCV_RVV) && (__riscv_xlen == 64)
+
+    return ZSTD_row_getRVVMask(rowEntries, src, tag, headGrouped);
+
+#else
+
+#if defined(ZSTD_ARCH_ARM_NEON)
   /* This NEON path only works for little endian - otherwise use SWAR below */
     if (MEM_isLittleEndian()) {
         return ZSTD_row_getNEONMask(rowEntries, src, tag, headGrouped);
     }
 
-# elif defined(ZSTD_ARCH_RISCV_RVV) && (__riscv_xlen == 64)
 
-    return ZSTD_row_getRVVMask(rowEntries, src, tag, headGrouped);
-
-#else
+#endif
     /* SWAR */
     {   const int chunkSize = sizeof(size_t);
         const size_t shiftAmount = ((chunkSize * 8) - chunkSize);


### PR DESCRIPTION
This pull request introduces a RISC-V Vector (RVV) specific optimization for the `ZSTD_row_getMatchMask` function, replacing the generic SWAR implementation on RV64 platforms with V-extension support. The goal is to leverage RVV's parallel computation capabilities to improve performance on the RISC-V architecture. The implementation follows a "Construct-Select-Reduce" strategy, which is detailed in the code

## Performance
### Microbenchmark Results
A microbenchmark isolating the `ZSTD_row_getMatchMask` function shows a significant speedup compared to the SWAR fallback.

| rowEntries | Speedup   |
| ---------- | --------- |
| 16 bytes   | **3.45x** |
| 32 bytes   | **4.24x** |
| 64 bytes   | **4.73x** |

### Fullbench

The overall impact on the `fullbench` is modest. However, the new implementation shows a consistent small improvement and, most importantly, **no performance regression**.

Ten consecutive runs were performed for both the original version and the RVV-optimized version. The RVV version demonstrates a **~0.3%** average performance increase for this specific function under these test conditions.

| Version    | Average Speed        | Fastest Run          | Slowest Run      |
| ---------- | -------------------- | -------------------- | ---------------- |
| **Origin** | 1,081,809.8 MB/s     | 1,091,072.1 MB/s     | 1,068,435.0 MB/s |
| **RVV**    | **1,085,074.8 MB/s** | **1,096,995.4 MB/s** | 1,063,997.2 MB/s |


## Validation
- [x] All quick check pass (`make check`).  
- [x] All longer check pass（`make test`）
- [x] Static analysis reports no new issues (`make staticAnalyze`).  

